### PR TITLE
Replace do '+' no filtro que é passado pela URL

### DIFF
--- a/src/Lumen/Http/Controllers/BaseController.php
+++ b/src/Lumen/Http/Controllers/BaseController.php
@@ -22,7 +22,7 @@ abstract class BaseController extends Controller
     {
         if ($filters instanceof Request) {
             if ($filters->has('filters')) {
-                $filters = json_decode(base64_decode($filters->input('filters')), true);
+                $filters = json_decode(base64_decode(str_replace(' ', '+', $filters->input('filters'))), true);
             } else {
                 $filters = [];
             }


### PR DESCRIPTION
Replace do '+' no filtro que é passado pela URL, pois por padrão é substituído por um espaço, e aí o base64 não faz o encoding correto